### PR TITLE
switch from using pip to homebrew

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: CI
+name: Generate SDK
 
 # Controls when the action will run. 
 on: [repository_dispatch, workflow_dispatch]
@@ -26,8 +26,7 @@ jobs:
       # Runs a single command using the runners shell
       - name: install openapi-generator
         run: |
-          python -m pip install --upgrade pip
-          pip install openapi-generator
+          brew install openapi-generator
 
       - name: generate sdk
         run: openapi-generator generate -i http://api.merge.dev/api/hris/v1/schema -g ruby -o . -c config.json


### PR DESCRIPTION
## Description of the change

> openapi-generator can't be installed by pip, need to use homebrew instead

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> https://app.asana.com/0/1198154734771987/1199405969443070/f

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests, or the description above explains how testing was performed

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or gif attached. Download "Kap" from the Mac App store for easy gif screen capture.
