### PR TITLE
remove prod key as parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,10 @@ MergeHRISClient.configure do |config|
 end
 
 api_instance = MergeHRISClient::AccountTokenApi.new
-production_key = 'production_key_example' # String | The requesting organization's production key.
 public_token = 'public_token_example' # String | 
 
 begin
-  result = api_instance.account_token_retrieve(production_key, public_token)
+  result = api_instance.account_token_retrieve(public_token)
   p result
 rescue MergeHRISClient::ApiError => e
   puts "Exception when calling AccountTokenApi->account_token_retrieve: #{e}"

--- a/docs/AccountTokenApi.md
+++ b/docs/AccountTokenApi.md
@@ -10,7 +10,7 @@ Method | HTTP request | Description
 
 ## account_token_retrieve
 
-> AccountToken account_token_retrieve(production_key, public_token)
+> AccountToken account_token_retrieve(public_token)
 
 
 
@@ -30,11 +30,10 @@ MergeHRISClient.configure do |config|
 end
 
 api_instance = MergeHRISClient::AccountTokenApi.new
-production_key = 'production_key_example' # String | The requesting organization's production key.
 public_token = 'public_token_example' # String | 
 
 begin
-  result = api_instance.account_token_retrieve(production_key, public_token)
+  result = api_instance.account_token_retrieve(public_token)
   p result
 rescue MergeHRISClient::ApiError => e
   puts "Exception when calling AccountTokenApi->account_token_retrieve: #{e}"
@@ -46,7 +45,6 @@ end
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **production_key** | **String**| The requesting organization&#39;s production key. | 
  **public_token** | **String**|  | 
 
 ### Return type

--- a/docs/LinkTokenApi.md
+++ b/docs/LinkTokenApi.md
@@ -10,7 +10,7 @@ Method | HTTP request | Description
 
 ## link_token_create
 
-> LinkToken link_token_create(production_key, end_user_details)
+> LinkToken link_token_create(end_user_details)
 
 
 
@@ -30,11 +30,10 @@ MergeHRISClient.configure do |config|
 end
 
 api_instance = MergeHRISClient::LinkTokenApi.new
-production_key = 'production_key_example' # String | The requesting organization's production key.
 end_user_details = MergeHRISClient::EndUserDetails.new # EndUserDetails | 
 
 begin
-  result = api_instance.link_token_create(production_key, end_user_details)
+  result = api_instance.link_token_create(end_user_details)
   p result
 rescue MergeHRISClient::ApiError => e
   puts "Exception when calling LinkTokenApi->link_token_create: #{e}"
@@ -46,7 +45,6 @@ end
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **production_key** | **String**| The requesting organization&#39;s production key. | 
  **end_user_details** | [**EndUserDetails**](EndUserDetails.md)|  | 
 
 ### Return type

--- a/lib/merge_hris_client/api/account_token_api.rb
+++ b/lib/merge_hris_client/api/account_token_api.rb
@@ -20,27 +20,21 @@ module MergeHRISClient
       @api_client = api_client
     end
     # Returns the account token for the end user with the provided public token.
-    # @param production_key [String] The requesting organization&#39;s production key.
     # @param public_token [String] 
     # @param [Hash] opts the optional parameters
     # @return [AccountToken]
-    def account_token_retrieve(production_key, public_token, opts = {})
-      data, _status_code, _headers = account_token_retrieve_with_http_info(production_key, public_token, opts)
+    def account_token_retrieve(public_token, opts = {})
+      data, _status_code, _headers = account_token_retrieve_with_http_info(public_token, opts)
       data
     end
 
     # Returns the account token for the end user with the provided public token.
-    # @param production_key [String] The requesting organization&#39;s production key.
     # @param public_token [String] 
     # @param [Hash] opts the optional parameters
     # @return [Array<(AccountToken, Integer, Hash)>] AccountToken data, response status code and response headers
-    def account_token_retrieve_with_http_info(production_key, public_token, opts = {})
+    def account_token_retrieve_with_http_info(public_token, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: AccountTokenApi.account_token_retrieve ...'
-      end
-      # verify the required parameter 'production_key' is set
-      if @api_client.config.client_side_validation && production_key.nil?
-        fail ArgumentError, "Missing the required parameter 'production_key' when calling AccountTokenApi.account_token_retrieve"
       end
       # verify the required parameter 'public_token' is set
       if @api_client.config.client_side_validation && public_token.nil?
@@ -51,7 +45,6 @@ module MergeHRISClient
 
       # query parameters
       query_params = opts[:query_params] || {}
-      query_params[:'production_key'] = production_key
 
       # header parameters
       header_params = opts[:header_params] || {}

--- a/lib/merge_hris_client/api/link_token_api.rb
+++ b/lib/merge_hris_client/api/link_token_api.rb
@@ -20,27 +20,21 @@ module MergeHRISClient
       @api_client = api_client
     end
     # Creates a link token to be used when linking a new end user.
-    # @param production_key [String] The requesting organization&#39;s production key.
     # @param end_user_details [EndUserDetails] 
     # @param [Hash] opts the optional parameters
     # @return [LinkToken]
-    def link_token_create(production_key, end_user_details, opts = {})
-      data, _status_code, _headers = link_token_create_with_http_info(production_key, end_user_details, opts)
+    def link_token_create(end_user_details, opts = {})
+      data, _status_code, _headers = link_token_create_with_http_info(end_user_details, opts)
       data
     end
 
     # Creates a link token to be used when linking a new end user.
-    # @param production_key [String] The requesting organization&#39;s production key.
     # @param end_user_details [EndUserDetails] 
     # @param [Hash] opts the optional parameters
     # @return [Array<(LinkToken, Integer, Hash)>] LinkToken data, response status code and response headers
-    def link_token_create_with_http_info(production_key, end_user_details, opts = {})
+    def link_token_create_with_http_info(end_user_details, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: LinkTokenApi.link_token_create ...'
-      end
-      # verify the required parameter 'production_key' is set
-      if @api_client.config.client_side_validation && production_key.nil?
-        fail ArgumentError, "Missing the required parameter 'production_key' when calling LinkTokenApi.link_token_create"
       end
       # verify the required parameter 'end_user_details' is set
       if @api_client.config.client_side_validation && end_user_details.nil?
@@ -51,7 +45,6 @@ module MergeHRISClient
 
       # query parameters
       query_params = opts[:query_params] || {}
-      query_params[:'production_key'] = production_key
 
       # header parameters
       header_params = opts[:header_params] || {}


### PR DESCRIPTION
## Description of the change

> No longer need production key for token endpoints since it's in the Auth header

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> https://app.asana.com/0/1198154734771987/1199605205111638/f

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests, or the description above explains how testing was performed

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or gif attached. Download "Kap" from the Mac App store for easy gif screen capture.
